### PR TITLE
Simplify no-redirect code

### DIFF
--- a/src/main/java/nl/hsac/fitnesse/fixture/Environment.java
+++ b/src/main/java/nl/hsac/fitnesse/fixture/Environment.java
@@ -320,7 +320,6 @@ public class Environment {
      */
     public void doGet(String url, HttpResponse response, Map<String, Object> headers, boolean followRedirect) {
         response.setRequest(url);
-        httpClient.followRedirect = followRedirect;
         httpClient.get(url, response, headers, followRedirect);
     }
 

--- a/src/main/java/nl/hsac/fitnesse/fixture/slim/HttpTest.java
+++ b/src/main/java/nl/hsac/fitnesse/fixture/slim/HttpTest.java
@@ -219,15 +219,19 @@ public class HttpTest extends SlimFixtureWithMap {
      * @return true if call could be made and response did not indicate error.
      */
     public boolean getFrom(String serviceUrl) {
-        return getFromFollowRedirect(serviceUrl, true);
+        return getImpl(serviceUrl, true);
     }
 
     /**
-     * Sends HTTP GET to service endpoint to retrieve content.
+     * Sends HTTP GET to service endpoint to retrieve content, not following a redirect if sent.
      * @param serviceUrl service endpoint to get content from.
      * @return true if call could be made and response did not indicate error.
      */
-    public boolean getFromFollowRedirect(String serviceUrl, boolean followRedirect) {
+    public boolean getFromNoRedirect(String serviceUrl) {
+        return getImpl(serviceUrl, false);
+    }
+
+    protected boolean getImpl(String serviceUrl, boolean followRedirect) {
         boolean result;
         resetResponse();
         String url = createUrlWithParams(serviceUrl);
@@ -239,7 +243,6 @@ public class HttpTest extends SlimFixtureWithMap {
         result = postProcessResponse();
         return result;
     }
-
 
 
     /**

--- a/src/test/java/nl/hsac/fitnesse/fixture/slim/HttpTestTest.java
+++ b/src/test/java/nl/hsac/fitnesse/fixture/slim/HttpTestTest.java
@@ -12,6 +12,8 @@ import static org.junit.Assert.assertTrue;
  * Tests HttpTest.
  */
 public class HttpTestTest {
+    // site that redirects
+    private static final String URL_WITH_REDIRECT = "http://www.hotmail.com";
     private final HttpTest client = new XmlHttpTest();
 
     @Test
@@ -97,25 +99,26 @@ public class HttpTestTest {
     }
 
 
-    /*
-        Test url redirects with follow redirects (default setting)
+    /**
+     * Tests url redirects with follow redirects (default setting)
      */
-    @Test public void testGetFromFollowRedirect() throws Exception {
-        String serviceUrl = "http://www.hotmail.com"; // Site that redircts
+    @Test
+    public void testGetFromFollowRedirect() throws Exception {
         HttpTest httpTest = new HttpTest();
-        boolean result = httpTest.getFrom(serviceUrl);
+        boolean result = httpTest.getFrom(URL_WITH_REDIRECT);
         String resp = httpTest.htmlResponse();
         assertNotNull(resp);
         assertEquals(200, httpTest.getResponse().getStatusCode());
         assertTrue(result);
     }
 
-
-
-    @Test public void testGetFrom() throws Exception {
-        String serviceUrl = "http://www.hotmail.com"; // Site that redircts
+    /**
+     * Test url redirects without following redirectØ
+     */
+    @Test
+    public void testGetFromNoRedirect() throws Exception {
         HttpTest httpTest = new HttpTest();
-        boolean result = httpTest.getFromFollowRedirect(serviceUrl, false);
+        boolean result = httpTest.getFromNoRedirect(URL_WITH_REDIRECT);
         String resp = httpTest.htmlResponse();
         assertNotNull(resp);
         assertEquals(301, httpTest.getResponse().getStatusCode());

--- a/wiki/FitNesseRoot/HsacExamples/SlimTests/HttpTests/HttpGetFollowRedirectTest/content.txt
+++ b/wiki/FitNesseRoot/HsacExamples/SlimTests/HttpTests/HttpGetFollowRedirectTest/content.txt
@@ -1,13 +1,15 @@
-First we do a 'normal' GET.
+!define REDIRECT_URL {http://www.hotmail.com}
 
-|script  |http test             |
-|get from|http://www.hotmail.com|
-|check   |response status  |200 |
+First we do a 'normal' GET to ${REDIRECT_URL}, which will redirect us.
+
+|script  |http test          |
+|get from|${REDIRECT_URL}    |
+|check   |response status|200|
 
 Then we do the same call without following the redirect, allowing us to inspect that a redirect is sent and what the redirect location is.
 
-|script  |http test                                                             |
-|get from|http://www.hotmail.com|no redirect                                    |
-|check   |response status       |301                                            |
-|check   |response header       |Location|!-https://mail.live.com/default.aspx-!|
-|show    |response                                                              |
+|script  |http test                                                      |
+|get from|${REDIRECT_URL}|no redirect                                    |
+|check   |response status|301                                            |
+|check   |response header|Location|!-https://mail.live.com/default.aspx-!|
+|show    |response                                                       |

--- a/wiki/FitNesseRoot/HsacExamples/SlimTests/HttpTests/HttpGetFollowRedirectTest/content.txt
+++ b/wiki/FitNesseRoot/HsacExamples/SlimTests/HttpTests/HttpGetFollowRedirectTest/content.txt
@@ -1,9 +1,13 @@
-!2 Http GET without follow redirect
+First we do a 'normal' GET.
 
-Performs HTTP GET adding values as parameters in the query string.
+|script  |http test             |
+|get from|http://www.hotmail.com|
+|check   |response status  |200 |
 
-|script         |xml http test                                                       |
-|get from       |http://www.hotmail.com         | follow redirect       | false      |
-|check          |response status|301                                                 |
-|show           |request                                                             |
-|show           |response                                                            |
+Then we do the same call without following the redirect, allowing us to inspect that a redirect is sent and what the redirect location is.
+
+|script  |http test                                                             |
+|get from|http://www.hotmail.com|no redirect                                    |
+|check   |response status       |301                                            |
+|check   |response header       |Location|!-https://mail.live.com/default.aspx-!|
+|show    |response                                                              |

--- a/wiki/FitNesseRoot/HsacExamples/SlimTests/HttpTests/HttpGetFollowRedirectTest/properties.xml
+++ b/wiki/FitNesseRoot/HsacExamples/SlimTests/HttpTests/HttpGetFollowRedirectTest/properties.xml
@@ -1,12 +1,13 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <properties>
-	<Edit>true</Edit>
-	<Files>true</Files>
-	<Properties>true</Properties>
-	<RecentChanges>true</RecentChanges>
-	<Refactor>true</Refactor>
-	<Search>true</Search>
-	<Test>true</Test>
-	<Versions>true</Versions>
-	<WhereUsed>true</WhereUsed>
+<Edit>true</Edit>
+<Files>true</Files>
+<Help>Http GET without following redirect</Help>
+<Properties>true</Properties>
+<RecentChanges>true</RecentChanges>
+<Refactor>true</Refactor>
+<Search>true</Search>
+<Test>true</Test>
+<Versions>true</Versions>
+<WhereUsed>true</WhereUsed>
 </properties>

--- a/wiki/FitNesseRoot/HsacExamples/SlimTests/HttpTests/content.txt
+++ b/wiki/FitNesseRoot/HsacExamples/SlimTests/HttpTests/content.txt
@@ -7,6 +7,7 @@ The tests in this suite show example usage of this fixture:
 The >HttpPost2UsingScenarioTest makes multiple SOAP calls to a service, where scenario parameters are used to change an input variable's value for each call.
 >HttpPost3UsingFreemarkerTemplateTest shows the usage of a [[Freemarker][http://freemarker.org]] template to define the content of a SOAP request. This allows for dynamic request structure.
 >JsonHttpTest shows examples with GET, POST, AND PUT, using [[!-JsonPath-!][http://goessner.net/articles/JsonPath/]] to perform checks on the response. 
+>HttpGetFollowRedirectTest shows checking the redirect sent by a server instead of following it.
 
 !2 Language
 
@@ -14,8 +15,8 @@ The >HttpPost2UsingScenarioTest makes multiple SOAP calls to a service, where sc
 The main commands/keywords (i.e. public methods) offered by !-nl.hsac.fitnesse.fixture.slim.HttpTest-! are listed below.
 
 -|Comment|
-|get from <url>                     |Sends a GET to the specified url (parameters can be added using 'set value(s) for').
-|get from follow redirect <url>     |Sends a GET to the specified url with the parameter you can stop or follow an redirect.     |
+|get from <url>                                                                                                                                                                                            |Sends a GET to the specified url (parameters can be added using 'set value(s) for').
+|get from <url> no redirect         |Sends a GET to the specified url not following redirects sent by the server.                                                                                          |
 |post <body> to <url>               |Sends a POST containing the specified body to the url.                                                                                                                |
 |post template to <url>             |Sends a POST to the specified url, determining the body by combining the configured template and values (see 'set value for' and 'template')                          |
 |put <body> to <url>                |Sends a PUT containing the specified body to the url.                                                                                                                 |


### PR DESCRIPTION
Auke,

I think the redirect handling is nicer this way:
- we only ignore redirect for those specific requests specifying that, instead of global strategy that may remain in unexpected state
- no extra boolean parameter required in wiki
- sample test makes same call in 2 ways to highlight difference

Does this work for you?
